### PR TITLE
chown pid directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.19
+
+* Ensure that the pids directory is owned by the user specified in the options file.

--- a/lib/procodile/config.rb
+++ b/lib/procodile/config.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'yaml'
 require 'fileutils'
 require 'procodile/error'
@@ -15,7 +16,9 @@ module Procodile
         raise Error, "Procfile not found at #{procfile_path}"
       end
       FileUtils.mkdir_p(pid_root)
-      FileUtils.chown_R(user, user, pid_root)
+      current_user = Etc.getpwuid(::File::Stat.new(pid_root).uid).name
+      current_group = Etc.getgrgid(::File::Stat.new(pid_root).gid).name
+      FileUtils.chown_R(user, user, pid_root) unless user == current_user && user == current_group
 
       @processes = process_list.each_with_index.each_with_object({}) do |((name, command), index), hash|
         hash[name] = create_process(name, command, COLORS[index.divmod(COLORS.size)[1]])

--- a/lib/procodile/config.rb
+++ b/lib/procodile/config.rb
@@ -15,7 +15,7 @@ module Procodile
         raise Error, "Procfile not found at #{procfile_path}"
       end
       FileUtils.mkdir_p(pid_root)
-      FileUtils.chown(user, user, pid_root)
+      FileUtils.chown_R(user, user, pid_root)
 
       @processes = process_list.each_with_index.each_with_object({}) do |((name, command), index), hash|
         hash[name] = create_process(name, command, COLORS[index.divmod(COLORS.size)[1]])

--- a/lib/procodile/config.rb
+++ b/lib/procodile/config.rb
@@ -15,6 +15,7 @@ module Procodile
         raise Error, "Procfile not found at #{procfile_path}"
       end
       FileUtils.mkdir_p(pid_root)
+      FileUtils.chown(user, user, pid_root)
 
       @processes = process_list.each_with_index.each_with_object({}) do |((name, command), index), hash|
         hash[name] = create_process(name, command, COLORS[index.divmod(COLORS.size)[1]])

--- a/lib/procodile/version.rb
+++ b/lib/procodile/version.rb
@@ -1,3 +1,3 @@
 module Procodile
-  VERSION = '1.0.18'
+  VERSION = '1.0.19'
 end


### PR DESCRIPTION
@adamcooke let me know if this seems OK to merge in, or if you would like changes. looking at the specs there didn't seem to be an appropriate test to add.

having some problems when our application deploys a new version. the pids directory is created, but owned by root and our application user cannot write to it.

```
---- Begin output of procodile start --root /opt/cool_app --procfile /opt/cool_app/Procfile.dj ----
    STDOUT:
    STDERR: Procodile must be run as cool_app. Re-executing as cool_app...
    /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:507:in `initialize': Permission denied @ rb_sysopen - /opt/cool_app/tmp/procodile-pids/procodile.pid (Errno::EACCES)
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:507:in `open'
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:507:in `start_supervisor'
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:155:in `start'
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:39:in `public_send'
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/lib/procodile/cli.rb:39:in `dispatch'
      from /opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/procodile-1.0.18/bin/procodile:93:in `<top (required)>'
      from /opt/rbenv/versions/2.3.1/bin/procodile:23:in `load'
      from /opt/rbenv/versions/2.3.1/bin/procodile:23:in `<main>'
    ---- End output of procodile start --root /opt/cool_app --procfile /opt/cool_app/Procfile.dj ----
    Ran procodile start --root /opt/cool_app --procfile /opt/cool_app/Procfile.dj returned 1
```

names have been changed to protect the innocent.