### PR TITLE
Stop the oldest instance first when finding too many processes

### DIFF
--- a/lib/procodile/supervisor.rb
+++ b/lib/procodile/supervisor.rb
@@ -259,7 +259,7 @@ module Procodile
             if instances.size > process.quantity
               quantity_to_stop = instances.size - process.quantity
               Procodile.log nil, "system", "Stopping #{quantity_to_stop} #{process.name} process(es)"
-              status[:stopped] = instances.last(quantity_to_stop).each(&:stop)
+              status[:stopped] = instances.first(quantity_to_stop).each(&:stop)
             end
           end
 

--- a/spec/apps/slow/Procfile
+++ b/spec/apps/slow/Procfile
@@ -1,0 +1,1 @@
+slow-worker: ruby process.rb slow-worker

--- a/spec/apps/slow/Procfile.options
+++ b/spec/apps/slow/Procfile.options
@@ -1,0 +1,4 @@
+processes:
+  slow-worker:
+    quantity: 1
+    restart_mode: start-term

--- a/spec/apps/slow/process.rb
+++ b/spec/apps/slow/process.rb
@@ -1,0 +1,6 @@
+puts "This is #{ENV['PROC_NAME']}. It stops slowly."
+trap('TERM') { sleep 10; Process.exit }
+
+loop do
+  sleep 1
+end


### PR DESCRIPTION
This prevents the process you've just spawned being killed if you do two start-terms in rapid succession