### PR TITLE
Support signal sequences for term_signal

### DIFF
--- a/lib/procodile/instance.rb
+++ b/lib/procodile/instance.rb
@@ -188,8 +188,10 @@ module Procodile
       @stopping = Time.now
       update_pid
       if self.running?
-        Procodile.log(@process.log_color, description, "Sending #{@process.term_signal} to #{@pid}")
-        ::Process.kill(@process.term_signal, pid)
+        Array(@process.term_signal).each do |signal|
+          Procodile.log(@process.log_color, description, "Sending #{signal} to #{@pid}")
+          ::Process.kill(signal, pid)
+        end
       else
         Procodile.log(@process.log_color, description, "Process already stopped")
       end


### PR DESCRIPTION
Just a tiny PR, which adds support of signal sequences for the `term_signal` option.

For example, if we follow [the sidekiq's guideline](https://github.com/mperham/sidekiq/wiki/Signals#tstp) and want to send TSTP + TERM signal, our `Procfile.options` will contain the next:

```yaml
processes:
  sidekiq:
    term_signal: [TSTP, TERM]
```